### PR TITLE
Move react to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "config": "^1.26.1",
     "line-height": "^0.3.1",
-    "react": "^15.6.1",
     "react-motion": "^0.5.0"
   },
   "devDependencies": {
@@ -66,6 +65,9 @@
     "style-loader": "^0.13.0",
     "webpack": "^1.12.2",
     "webpack-stream": "^3.1.0"
+  },
+  "peerDependencies": {
+    "react": "^15.6.1"
   },
   "bugs": {
     "url": "https://github.com/mishantrop/reactScrollbar/issues"


### PR DESCRIPTION
Fixes problem with having two different versions of react installed by `yarn`.