### PR TITLE
Remove unnecessary 'scrollbar-container--' prefix from classnames

### DIFF
--- a/src/js/Scrollbar.js
+++ b/src/js/Scrollbar.js
@@ -234,9 +234,9 @@ ScrollBar.propTypes = {
 
 ScrollBar.defaultProps = {
   containerClassName: 'scrollbar-container',
-  containerClassNameActive: 'scrollbar-container--active',
-  containerClassNameHorizontal: 'scrollbar-container--horizontal',
-  containerClassNameVertical: 'scrollbar-container--vertical',
+  containerClassNameActive: 'active',
+  containerClassNameHorizontal: 'horizontal',
+  containerClassNameVertical: 'vertical',
   scrollbarClassName: 'scrollbar',
   smoothScrolling: false,
   type: 'vertical',


### PR DESCRIPTION
In response to [Issue #2](https://github.com/mishantrop/reactScrollarea/issues/2#issue-274131440).  This should fix the class naming issue.